### PR TITLE
Fix cv_image '=' overload for Mat in latest OpenCV

### DIFF
--- a/dlib/opencv/cv_image.h
+++ b/dlib/opencv/cv_image.h
@@ -142,7 +142,11 @@ namespace dlib
 
         cv_image& operator=( const cv::Mat img)
         {
+#if CV_MAJOR_VERSION > 3
+            IplImage temp = cvIplImage(img);
+#else
             IplImage temp = img;
+#endif
             init(&temp);
             return *this;
         }


### PR DESCRIPTION
This addresses same issue as #1949, but for cv_image '=' operator overloading cv::Mat images. 

**For example:**
cv_image<bgr_pixel> cimg;
cv::Mat img;
cimg = img;